### PR TITLE
Integrate Clones from OpenZeppelin

### DIFF
--- a/blockchain/contracts/Clones.sol
+++ b/blockchain/contracts/Clones.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (proxy/Clones.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-1167[EIP 1167] is a standard for
+ * deploying minimal proxy contracts, also known as "clones".
+ *
+ * > To simply and cheaply clone contract functionality in an immutable way, this standard specifies
+ * > a minimal bytecode implementation that delegates all calls to a known, fixed address.
+ *
+ * The library includes functions to deploy a proxy using either `create` (traditional deployment) or `create2`
+ * (salted deterministic deployment). It also includes functions to predict the addresses of clones deployed using the
+ * deterministic method.
+ *
+ * _Available since v3.4._
+ */
+library Clones {
+    /**
+     * @dev Deploys and returns the address of a clone that mimics the behaviour of `implementation`.
+     *
+     * This function uses the create opcode, which should never revert.
+     */
+    function clone(address implementation) internal returns (address instance) {
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, implementation))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            instance := create(0, ptr, 0x37)
+        }
+        require(instance != address(0), "ERC1167: create failed");
+    }
+
+    /**
+     * @dev Deploys and returns the address of a clone that mimics the behaviour of `implementation`.
+     *
+     * This function uses the create2 opcode and a `salt` to deterministically deploy
+     * the clone. Using the same `implementation` and `salt` multiple time will revert, since
+     * the clones cannot be deployed twice at the same address.
+     */
+    function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, implementation))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            instance := create2(0, ptr, 0x37, salt)
+        }
+        require(instance != address(0), "ERC1167: create2 failed");
+    }
+
+    /**
+     * @dev Computes the address of a clone deployed using {Clones-cloneDeterministic}.
+     */
+    function predictDeterministicAddress(
+        address implementation,
+        bytes32 salt,
+        address deployer
+    ) internal pure returns (address predicted) {
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, implementation))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf3ff00000000000000000000000000000000)
+            mstore(add(ptr, 0x38), shl(0x60, deployer))
+            mstore(add(ptr, 0x4c), salt)
+            mstore(add(ptr, 0x6c), keccak256(ptr, 0x37))
+            predicted := keccak256(add(ptr, 0x37), 0x55)
+        }
+    }
+
+    /**
+     * @dev Computes the address of a clone deployed using {Clones-cloneDeterministic}.
+     */
+    function predictDeterministicAddress(address implementation, bytes32 salt)
+        internal
+        view
+        returns (address predicted)
+    {
+        return predictDeterministicAddress(implementation, salt, address(this));
+    }
+}

--- a/blockchain/migrations/2_deploy_contracts.js
+++ b/blockchain/migrations/2_deploy_contracts.js
@@ -1,7 +1,11 @@
+const Clones = artifacts.require("Clones");
+const Campaign = artifacts.require("Campaign");
 const CampaignFactory = artifacts.require("CampaignFactory");
 
-module.exports = function (deployer, network, accounts) {
-  deployer.deploy(CampaignFactory, {
+module.exports = async function (deployer, network, accounts) {
+  await deployer.deploy(Clones);
+  await deployer.deploy(Campaign);
+  await deployer.deploy(CampaignFactory, Campaign.address, {
     from: accounts[0],
     value: web3.utils.toWei("0.1", "ether")
   });

--- a/blockchain/test/1_test_campaignfactory.js
+++ b/blockchain/test/1_test_campaignfactory.js
@@ -9,11 +9,12 @@ contract("CampaignFactory", (accounts) => {
   const campaignOwner = accounts[2];
 
   let campaignFactoryInstance;
-  let campaignInstance;
+  let campaignImplementation;
 
   before(async () => {
+    campaignImplementation = await Campaign.new();
     const deploymentAmount = web3.utils.toWei("0.01", "ether");
-    campaignFactoryInstance = await CampaignFactory.new({
+    campaignFactoryInstance = await CampaignFactory.new(campaignImplementation.address, {
       from: deployingAccount,
       value: deploymentAmount
     });
@@ -43,8 +44,7 @@ contract("CampaignFactory", (accounts) => {
 
     // Update new campaign instance
     const campaignAddress = tx.logs[0].args.campaignAddress;
-    campaignInstance = await Campaign.at(campaignAddress);
-
+    const campaignInstance = await Campaign.at(campaignAddress);
     console.log("Campaign has been deployed at " + campaignInstance.address);
   });
 });


### PR DESCRIPTION
`Clones.sol` referenced from [here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.5.0/contracts/proxy/Clones.sol)

How it works:
1. `Campaign` contract is created first. We call this the implementation contract because it contains the implementation code.
2. When a new campaign is created, `campaignFactory` creates a clone of the implementation contract from step (1). The clone's `init()` function, which is pointed to the implementation contract's `init()`, will be called to fill the different fields.
3. The address returned from creating the clone will be returned and can be used as if it was a normal `Campaign`

Tests and migration scripts have been updated to reflect this new change.

Fixes #46